### PR TITLE
fix: change wallpaper for dark mode in gnome 42

### DIFF
--- a/chwall/wallpaper.py
+++ b/chwall/wallpaper.py
@@ -159,11 +159,19 @@ def set_gnome_wallpaper(path, where="background"):
         return prop_setting_error_str(
             "gnome", "{where} {prop}".format(where=where, prop=prop)
         )
-
+    p = subprocess.run(
+        ["gsettings", "list-keys", "org.gnome.desktop.{}".format(where)],
+        capture_output=True, text=True)
+    err2 = 0
+    if "picture-uri-dark" in p.stdout:
+        err2 = subprocess.run(
+            ["gsettings", "set", "org.gnome.desktop.{}".format(where),
+             "picture-uri-dark", "file://{}".format(path)]).returncode
     err = subprocess.run(
         ["gsettings", "set", "org.gnome.desktop.{}".format(where),
          "picture-uri", "file://{}".format(path)]).returncode
-    if err == 1:
+    
+    if err == 1 or err2 == 1:
         raise ChwallWallpaperSetError(_format_prop_error("picture-uri"))
     err = subprocess.run(
         ["gsettings", "set", "org.gnome.desktop.{}".format(where),


### PR DESCRIPTION
This will fix issue #2 
Gnome 42 added different wallpapers for light and dark mode.