### PR TITLE
Add KDE Plasma desktop environment support

### DIFF
--- a/CONFIG.org
+++ b/CONFIG.org
@@ -41,7 +41,7 @@ objects:
 #+begin_src yaml
 ---
 general:
-  desktop: plasma  # For KDE Plasma users
+  desktop: gnome
   shared:
     path: /var/cache/last-wall
   sources:

--- a/CONFIG.org
+++ b/CONFIG.org
@@ -21,6 +21,10 @@ objects:
 
 ~general~ may contains the following subkeys:
 
+- ~desktop~ specifies which desktop environment or window manager you are
+  using. Supported values are: ~gnome~, ~xfce~, ~mate~, ~plasma~ (for KDE
+  Plasma), ~sway~, and ~feh~ (for lightweight window managers). If not
+  specified, ~gnome~ is used as default.
 - ~shared~, which is an object containing at least another subkey:
   ~path~. This must be the path to a writable file, which will always
   contains the last set wallpaper. This is usefull to display the same
@@ -37,6 +41,7 @@ objects:
 #+begin_src yaml
 ---
 general:
+  desktop: plasma  # For KDE Plasma users
   shared:
     path: /var/cache/last-wall
   sources:

--- a/README.org
+++ b/README.org
@@ -29,7 +29,8 @@ sources:
 - Wallhaven
 
 It currently supports some major desktop environments (Gnome, XFCE,
-Mate, KDE Plasma) and light window managers (Sway and anything accepting feh).
+Mate, KDE Plasma) and light window managers (Sway and anything
+accepting feh).
 
 * Install
 

--- a/README.org
+++ b/README.org
@@ -29,7 +29,7 @@ sources:
 - Wallhaven
 
 It currently supports some major desktop environments (Gnome, XFCE,
-Mate) and light window managers (Sway and anything accepting feh).
+Mate, KDE Plasma) and light window managers (Sway and anything accepting feh).
 
 * Install
 

--- a/chwall.yml.example
+++ b/chwall.yml.example
@@ -9,8 +9,7 @@ bing:
   - ja-JP
 general:
   # Desktop environment: gnome, xfce, mate, sway, feh, plasma
-  # For KDE Plasma, use: desktop: plasma
-  # desktop: plasma
+  desktop: gnome
   shared:
     path: /var/cache/last-wall
   sources:

--- a/chwall.yml.example
+++ b/chwall.yml.example
@@ -8,6 +8,9 @@ bing:
   - de-DE
   - ja-JP
 general:
+  # Desktop environment: gnome, xfce, mate, sway, feh, plasma
+  # For KDE Plasma, use: desktop: plasma
+  # desktop: plasma
   shared:
     path: /var/cache/last-wall
   sources:

--- a/chwall/gui/preferences.py
+++ b/chwall/gui/preferences.py
@@ -593,6 +593,12 @@ class PrefDialog(Gtk.Dialog):
         )
         genbox.pack_start(prefbox, False, False, 0)
 
+        prefbox = self.make_toggle_pref(
+            "general", "lock_screen_sync",
+            _("Sync lock screen wallpaper with desktop wallpaper (KDE Plasma)"),
+            default=False)
+        genbox.pack_start(prefbox, False, False, 0)
+
         daemonbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         daemonbox.set_border_width(10)
         daemonbox.set_spacing(10)

--- a/chwall/gui/preferences.py
+++ b/chwall/gui/preferences.py
@@ -566,9 +566,9 @@ class PrefDialog(Gtk.Dialog):
         genbox.pack_start(prefbox, False, False, 0)
 
         environments = [("gnome", "Gnome, Pantheon, Budgie, …"),
+                        ("plasma", "KDE Plasma"),
                         ("mate", "Mate"),
                         ("xfce", "XFCE"),
-                        ("plasma", "KDE Plasma"),
                         ("sway", "Sway"),
                         ("feh", _("Use Feh application"))]
         prefbox = self.make_select_pref(
@@ -594,7 +594,7 @@ class PrefDialog(Gtk.Dialog):
         genbox.pack_start(prefbox, False, False, 0)
 
         prefbox = self.make_toggle_pref(
-            "general", "lock_screen_sync",
+            "general", "kde_screen_locker_sync",
             _("Sync lock screen wallpaper with desktop wallpaper (KDE Plasma)"),
             default=False)
         genbox.pack_start(prefbox, False, False, 0)

--- a/chwall/gui/preferences.py
+++ b/chwall/gui/preferences.py
@@ -568,6 +568,7 @@ class PrefDialog(Gtk.Dialog):
         environments = [("gnome", "Gnome, Pantheon, Budgie, …"),
                         ("mate", "Mate"),
                         ("xfce", "XFCE"),
+                        ("plasma", "KDE Plasma"),
                         ("sway", "Sway"),
                         ("feh", _("Use Feh application"))]
         prefbox = self.make_select_pref(

--- a/chwall/utils.py
+++ b/chwall/utils.py
@@ -132,7 +132,7 @@ def read_config():
     config["general"].setdefault(
         "favorites_path", f"{BASE_CACHE_PATH}/favorites"
     )
-    config["general"].setdefault("lock_screen_sync", False)
+    config["general"].setdefault("kde_screen_locker_sync", False)
     return migrate_config(config)
 
 

--- a/chwall/utils.py
+++ b/chwall/utils.py
@@ -132,6 +132,7 @@ def read_config():
     config["general"].setdefault(
         "favorites_path", f"{BASE_CACHE_PATH}/favorites"
     )
+    config["general"].setdefault("lock_screen_sync", False)
     return migrate_config(config)
 
 

--- a/chwall/wallpaper.py
+++ b/chwall/wallpaper.py
@@ -224,6 +224,15 @@ def set_gnome_screensaver(path):
     set_gnome_wallpaper(path, "screensaver")
 
 
+def set_plasma_wallpaper(path):
+    if path is None:
+        raise ChwallWallpaperSetError(_("No wallpaper path given"))
+    err = subprocess.run(["plasma-apply-wallpaperimage", path]).returncode
+    if err != 0:
+        raise ChwallWallpaperSetError(
+            _("Error while calling plasma-apply-wallpaperimage"))
+
+
 def blur_picture(path, ld_path, radius):
     try:
         with Image.open(path) as im:


### PR DESCRIPTION
Add support for changing wallpapers in KDE Plasma using the plasma-apply-wallpaperimage command.

Changes:
- Add set_plasma_wallpaper() function in chwall/wallpaper.py
- Add 'KDE Plasma' option to desktop environment selector in GUI
- Update configuration example with plasma desktop option
- Update README to list KDE Plasma as supported environment
- Add detailed configuration documentation in CONFIG.org

Users can now select KDE Plasma from the preferences GUI or set 'desktop: plasma' in their chwall.yml configuration file to use plasma-apply-wallpaperimage for wallpaper changes.